### PR TITLE
Adding tokio functionality to reports.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ serde = "1.0.201"
 serde_derive = "1.0.201"
 tempfile = "3.10.1"
 tinyset = "0.4.15"
+tokio = { version = "1", features = ["full"] }

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -106,7 +106,7 @@ where
 {
     move |item| {
         if let Err(e) = sender.try_send((id, item)) {
-            eprintln!("{}", e);
+            panic!("Failed to send item: {:?}", e);
         }
     }
 }

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -119,9 +119,9 @@ mod test {
     };
     use serde_derive::Serialize;
     use std::io::{Read, Seek};
+    use tempfile::tempfile;
     use tokio::sync::mpsc;
     use tokio::task;
-    use tempfile::tempfile;
 
     crate::context::define_plugin!(TestReport, (), ());
 

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -4,7 +4,7 @@ use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io;
-use std::sync::mpsc::Sender;
+use tokio::sync::mpsc::Sender;
 
 pub trait Report: Any {
     type Item;
@@ -101,11 +101,11 @@ pub fn get_channel_report_handler<T: Report, S>(
     id: S,
 ) -> impl FnMut(T::Item) + 'static
 where
-    T::Item: Serialize + Send,
+    T::Item: Serialize + Send + 'static,
     S: Serialize + Send + Copy + 'static,
 {
     move |item| {
-        if let Err(e) = sender.send((id, item)) {
+        if let Err(e) = sender.try_send((id, item)) {
             eprintln!("{}", e);
         }
     }


### PR DESCRIPTION
@ekr-cfa 
get_channel_report_handler  function needs to use tokio::sync::mpsc::Sender instead of std::sync::mpsc::Sender. This is necessary for tokio to work with multi-threading in eosim-demo. 